### PR TITLE
Dataclass Enum Representation

### DIFF
--- a/python/evalio/cli/__init__.py
+++ b/python/evalio/cli/__init__.py
@@ -12,7 +12,7 @@ from .parser import DatasetBuilder, PipelineBuilder, parse_config
 def dataset_completer(**kwargs):
     datasets = DatasetBuilder._all_datasets()
     datasets = itertools.chain.from_iterable(
-        [f"{d.name()}/{seq}" for seq in d.sequences()] for d in datasets.values()
+        [seq.full_name for seq in d.sequences()] for d in datasets.values()
     )
     return datasets
 
@@ -34,7 +34,7 @@ def main():
     download = subparsers.add_parser("download", help="Download datasets")
     download.add_argument(
         "datasets", type=str, help="Dataset(s) to download", nargs="+"
-    ).completer = dataset_completer
+    ).completer = dataset_completer  # type: ignore
 
     # ls
     ls_opt = subparsers.add_parser("ls", help="List available datasets and pipelines")
@@ -47,10 +47,10 @@ def main():
     by_hand = run.add_argument_group("Manually specify options")
     by_hand.add_argument(
         "-d", "--datasets", type=str, nargs="+", help="Dataset(s) to run on"
-    ).completer = dataset_completer
+    ).completer = dataset_completer  # type: ignore
     by_hand.add_argument(
         "-p", "--pipeline", type=str, nargs="+", help="Pipeline(s) to run"
-    ).completer = pipeline_completer
+    ).completer = pipeline_completer  # type: ignore
     by_hand.add_argument("-o", "--output", type=Path, help="Output directory")
     by_hand.add_argument(
         "-l", "--length", type=int, help="Number of scans to process for each dataset"

--- a/python/evalio/cli/download.py
+++ b/python/evalio/cli/download.py
@@ -8,7 +8,7 @@ def download_datasets(datasets: list[str]) -> None:
     # Check if already downloaded
     to_download = []
     for builder in valid_datasets:
-        if builder.check_download():
+        if builder.is_downloaded():
             print(f"Skipping download for {builder}, already exists")
         else:
             to_download.append(builder)

--- a/python/evalio/cli/ls.py
+++ b/python/evalio/cli/ls.py
@@ -8,9 +8,9 @@ def ls(kind):
         data = [["Name", "Sequences", "Down", "Link"]]
         for d in DatasetBuilder._all_datasets().values():
             seq = "\n".join(d.sequences())
-            downloaded = [d.check_download(s) for s in d.sequences()]
+            downloaded = [d(s).is_downloaded() for s in d.sequences()]
             downloaded = "\n".join(["✔" if d else "-" for d in downloaded])
-            data.append([d.name(), seq, downloaded, d.url()])
+            data.append([d.dataset_name(), seq, downloaded, d.url()])
         print(
             tabulate(
                 data,
@@ -28,6 +28,9 @@ def ls(kind):
             keys = "\n".join(params.keys())
             values = "\n".join([str(v) for v in params.values()])
             data.append([p.name(), keys, values, p.url()])
+        if len(data) == 1:
+            print("No pipelines found")
+            return
         print(
             tabulate(
                 data,

--- a/python/evalio/cli/parser.py
+++ b/python/evalio/cli/parser.py
@@ -16,19 +16,20 @@ from evalio.pipelines import Pipeline
 def find_types(module, skip=None) -> dict[str, type]:
     found: dict[str, type] = {}
     found |= dict(
-        (cls.name(), cls)  # type:ignore
+        (cls.dataset_name(), cls)
         for cls in module.__dict__.values()
-        if isinstance(cls, type) and cls.__name__ != skip.__name__
+        if isinstance(cls, type) and cls.__name__ != skip.__name__  # type:ignore
     )
 
     return found
 
 
 # ------------------------- Parsing input ------------------------- #
+# TODO: Find a better way to handle lengths here
+# TODO: Make an experiment class to wrap all of this?
 @dataclass
 class DatasetBuilder:
-    dataset: type[Dataset]
-    seq: str
+    dataset: Dataset
     length: Optional[int] = None
 
     @staticmethod
@@ -48,7 +49,7 @@ class DatasetBuilder:
         return DatasetType
 
     @classmethod
-    def parse(cls, d: dict | str | Sequence[dict | str]) -> Sequence["DatasetBuilder"]:
+    def parse(cls, d: dict | str | Sequence[dict | str]) -> list["DatasetBuilder"]:
         # If empty just return
         if d is None:
             return []
@@ -58,11 +59,11 @@ class DatasetBuilder:
             name, seq = d.split("/")
             if seq == "*":
                 return [
-                    DatasetBuilder(cls._get_dataset(name), seq)
+                    DatasetBuilder(cls._get_dataset(name)(seq))
                     for seq in cls._get_dataset(name).sequences()
                 ]
             else:
-                return [DatasetBuilder(cls._get_dataset(name), seq)]
+                return [DatasetBuilder(cls._get_dataset(name)(seq))]
 
         # If given a dictionary
         elif isinstance(d, dict):
@@ -71,11 +72,11 @@ class DatasetBuilder:
             assert len(d) == 0, f"Invalid dataset configuration {d}"
             if seq == "*":
                 return [
-                    DatasetBuilder(cls._get_dataset(name), seq, length)
+                    DatasetBuilder(cls._get_dataset(name)(seq), length)
                     for seq in cls._get_dataset(name).sequences()
                 ]
             else:
-                return [DatasetBuilder(cls._get_dataset(name), seq, length)]
+                return [DatasetBuilder(cls._get_dataset(name)(seq), length)]
 
         # If given a list, iterate
         elif isinstance(d, list):
@@ -86,26 +87,23 @@ class DatasetBuilder:
             raise ValueError(f"Invalid dataset configuration {d}")
 
     def as_dict(self) -> dict[str, str | int]:
-        out: dict[str, str | int] = {"name": f"{self.dataset.name()}/{self.seq}"}
+        out: dict[str, str | int] = {"name": self.dataset.full_name}
         if self.length is not None:
             out["length"] = self.length
 
         return out
 
-    def __post_init__(self):
-        self.seq = self.dataset.process_seq(self.seq)
-
-    def check_download(self) -> bool:
-        return self.dataset.check_download(self.seq)
+    def is_downloaded(self) -> bool:
+        return self.dataset.is_downloaded()
 
     def download(self) -> None:
-        self.dataset.download(self.seq)
+        self.dataset.download()
 
     def build(self) -> Dataset:
-        return self.dataset(self.seq, self.length)
+        return self.dataset
 
-    def __str__(self):
-        return f"{self.dataset.name()}/{self.seq}"
+    def __str__(self) -> str:
+        return self.dataset
 
 
 @dataclass
@@ -117,13 +115,11 @@ class PipelineBuilder:
     def __post_init__(self):
         # Make sure all parameters are valid
         all_params = self.pipeline.default_params()
-        # TODO: Find a way to handle this gracefully for the wrapper
-        # Maybe a function in the pipeline class?
-        # for key in self.params.keys():
-        #     if key not in all_params:
-        #         raise ValueError(
-        #             f"Invalid parameter {key} for pipeline {self.pipeline.name()}"
-        #         )
+        for key in self.params.keys():
+            if key not in all_params:
+                raise ValueError(
+                    f"Invalid parameter {key} for pipeline {self.pipeline.name()}"
+                )
 
         # Save all params to file later
         all_params.update(self.params)
@@ -146,7 +142,7 @@ class PipelineBuilder:
         return PipelineType
 
     @classmethod
-    def parse(cls, p: dict | str | Sequence[dict | str]) -> Sequence["PipelineBuilder"]:
+    def parse(cls, p: dict | str | Sequence[dict | str]) -> list["PipelineBuilder"]:
         # If empty just return
         if p is None:
             return []
@@ -205,7 +201,7 @@ class PipelineBuilder:
 
 def parse_config(
     config_file: Optional[Path],
-) -> tuple[Sequence[PipelineBuilder], Sequence[DatasetBuilder], Optional[Path]]:
+) -> tuple[list[PipelineBuilder], list[DatasetBuilder], Optional[Path]]:
     if config_file is None:
         return ([], [], None)
 

--- a/python/evalio/cli/run.py
+++ b/python/evalio/cli/run.py
@@ -37,7 +37,7 @@ def run(
 
             # Initialize params
             # first_scan_done = False
-            data_iter = iter(dataset)
+            data_iter = dataset.data_iter()
             length = len(data_iter)
             if dbuilder.length is not None and dbuilder.length < length:
                 length = dbuilder.length

--- a/python/evalio/cli/writer.py
+++ b/python/evalio/cli/writer.py
@@ -26,7 +26,7 @@ def save_config(
 
 class TrajectoryWriter:
     def __init__(self, path: Path, pipeline: PipelineBuilder, dataset: DatasetBuilder):
-        path = path / dataset.dataset.name() / dataset.seq
+        path = path / dataset.dataset.full_name
         path.mkdir(parents=True, exist_ok=True)
         path /= f"{pipeline.name}.csv"
 
@@ -38,8 +38,8 @@ class TrajectoryWriter:
         for key, value in pipeline.params.items():
             self.file.write(f"# {key}: {value}\n")
         self.file.write("#\n")
-        self.file.write(f"# dataset: {dataset.dataset.name()}\n")
-        self.file.write(f"# sequence: {dataset.seq}\n")
+        self.file.write(f"# dataset: {dataset.dataset.dataset_name()}\n")
+        self.file.write(f"# sequence: {dataset.dataset.seq_name}\n")
         if dataset.length is not None:
             self.file.write(f"# length: {dataset.length}\n")
         self.file.write("#\n")
@@ -73,12 +73,12 @@ class TrajectoryWriter:
 
 def save_gt(output: Path, dataset: DatasetBuilder):
     gt = dataset.build().ground_truth()
-    path = output / dataset.dataset.name() / dataset.seq
+    path = output / dataset.dataset.full_name
     path.mkdir(parents=True, exist_ok=True)
     path = path / "gt.csv"
     with open(path, "w") as f:
-        f.write(f"# dataset: {dataset.dataset.name()}\n")
-        f.write(f"# sequence: {dataset.seq}\n")
+        f.write(f"# dataset: {dataset.dataset.dataset_name()}\n")
+        f.write(f"# sequence: {dataset.dataset.seq_name}\n")
         f.write("# gt: True\n")
         f.write("#\n")
         f.write("# timestamp, x, y, z, qx, qy, qz, qw\n")

--- a/python/evalio/datasets/__init__.py
+++ b/python/evalio/datasets/__init__.py
@@ -5,7 +5,7 @@ from .helipr import HeLiPR
 from .hilti_2022 import Hilti2022
 from .newer_college_2020 import NewerCollege2020
 from .newer_college_2021 import NewerCollege2021
-from .multi_campus_2024 import MultiCampus2024
+from .multi_campus import MultiCampus
 from .oxford_spires import OxfordSpires
 
 from . import iterators
@@ -19,6 +19,6 @@ __all__ = [
     "Hilti2022",
     "NewerCollege2020",
     "NewerCollege2021",
-    "MultiCampus2024",
+    "MultiCampus",
     "OxfordSpires",
 ]

--- a/python/evalio/datasets/base.py
+++ b/python/evalio/datasets/base.py
@@ -34,6 +34,9 @@ class DatasetIterator(Iterable[Measurement]):
 
     def __iter__(self) -> Iterator[Measurement]: ...
 
+    # Return the number of lidar scans
+    def __len__(self) -> int: ...
+
 
 class Dataset(StrEnum):
     # ------------------------- For loading data ------------------------- #
@@ -85,17 +88,16 @@ class Dataset(StrEnum):
 
         return gt_traj
 
-    def get_one_lidar(self, idx: int = 0) -> LidarMeasurement:
-        return next(islice(self.lidar(), idx, idx + 1))
-
-    def get_one_imu(self, idx: int = 0) -> ImuMeasurement:
-        return next(islice(self.imu(), idx, idx + 1))
-
     def _fail_not_downloaded(self):
         if not self.is_downloaded():
             raise ValueError(
                 f"Data for {self} not found, please use `evalio download {self}` to download"
             )
+
+    # ------------------------- Helpers that leverage from the iterator ------------------------- #
+
+    def __len__(self) -> int:
+        return self.data_iter().__len__()
 
     def __iter__(self) -> Iterator[Measurement]:  # type: ignore
         self._fail_not_downloaded()
@@ -108,6 +110,12 @@ class Dataset(StrEnum):
     def lidar(self) -> Iterable[LidarMeasurement]:
         self._fail_not_downloaded()
         return self.data_iter().lidar_iter()
+
+    def get_one_lidar(self, idx: int = 0) -> LidarMeasurement:
+        return next(islice(self.lidar(), idx, idx + 1))
+
+    def get_one_imu(self, idx: int = 0) -> ImuMeasurement:
+        return next(islice(self.imu(), idx, idx + 1))
 
     # ------------------------- Misc name helpers ------------------------- #
     def __str__(self):

--- a/python/evalio/datasets/base.py
+++ b/python/evalio/datasets/base.py
@@ -61,6 +61,7 @@ class Dataset(StrEnum):
     def download(self) -> None:
         raise NotImplementedError("Download not implemented")
 
+    # TODO: This would match better as a "classproperty", but not will involve some work
     @classmethod
     def dataset_name(cls) -> str:
         return pascal_to_snake(cls.__name__)
@@ -118,7 +119,7 @@ class Dataset(StrEnum):
 
     @property
     def full_name(self) -> str:
-        return f"{self.dataset_name}/{self.seq_name}"
+        return f"{self.dataset_name()}/{self.seq_name}"
 
     @classmethod
     def sequences(cls) -> list["Dataset"]:

--- a/python/evalio/datasets/base.py
+++ b/python/evalio/datasets/base.py
@@ -1,9 +1,10 @@
 import csv
 import os
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, Protocol, Union
+from typing import Iterable, Iterator, Optional, Union
 from itertools import islice
+
+from enum import StrEnum, auto, Enum
 
 import numpy as np
 from evalio.types import (
@@ -26,7 +27,7 @@ EVALIO_DATA = Path(os.getenv("EVALIO_DATA", "./data"))
 Measurement = Union[ImuMeasurement, LidarMeasurement]
 
 
-class DatasetIterator(Iterable[Measurement], Protocol):
+class DatasetIterator(Iterable[Measurement]):
     def imu_iter(self) -> Iterator[ImuMeasurement]: ...
 
     def lidar_iter(self) -> Iterator[LidarMeasurement]: ...
@@ -34,25 +35,16 @@ class DatasetIterator(Iterable[Measurement], Protocol):
     def __iter__(self) -> Iterator[Measurement]: ...
 
 
-@dataclass
-class Dataset(Protocol):
-    seq: str
-    length: Optional[int] = None
-
+class Dataset(StrEnum):
     # ------------------------- For loading data ------------------------- #
     def data_iter(self) -> DatasetIterator: ...
 
+    # Return the ground truth in the ground truth frame
     def ground_truth_raw(self) -> Trajectory: ...
 
     # ------------------------- For loading params ------------------------- #
     @staticmethod
     def url() -> str: ...
-
-    @staticmethod
-    def name() -> str: ...
-
-    @staticmethod
-    def sequences() -> list[str]: ...
 
     def imu_T_lidar(self) -> SE3: ...
 
@@ -62,30 +54,24 @@ class Dataset(Protocol):
 
     def lidar_params(self) -> LidarParams: ...
 
-    # ------------------------- For downloading ------------------------- #
-    @staticmethod
-    def check_download(seq: str) -> bool:
-        return True
+    def files(self) -> list[str]: ...
 
-    @staticmethod
-    def download(seq: str) -> None:
+    # ------------------------- Optional overrides ------------------------- #
+    # Optional method
+    def download(self) -> None:
         raise NotImplementedError("Download not implemented")
 
-    # ------------------------- Helpers ------------------------- #
-    def __post_init__(self):
-        self.seq = self.process_seq(self.seq)
-
-        if not self.check_download(self.seq):
-            raise ValueError(
-                f"Data for {self.seq} not found, please use `evalio download {self.name()}/{self.seq}` to download"
-            )
-
     @classmethod
-    def process_seq(cls, seq: str):
-        if seq not in cls.sequences():
-            raise ValueError(f"Sequence {seq} not in {cls.name()}")
+    def dataset_name(cls) -> str:
+        return pascal_to_snake(cls.__name__)
 
-        return seq
+    # ------------------------- Helpers that wrap the above ------------------------- #
+    def is_downloaded(self) -> bool:
+        for f in self.files():
+            if not (EVALIO_DATA / self / f).exists():
+                return False
+
+        return True
 
     def ground_truth(self) -> Trajectory:
         gt_traj = self.ground_truth_raw()
@@ -99,22 +85,79 @@ class Dataset(Protocol):
         return gt_traj
 
     def get_one_lidar(self, idx: int = 0) -> LidarMeasurement:
-        return next(islice(self.lidar_iter(), idx, idx + 1))
+        return next(islice(self.lidar(), idx, idx + 1))
 
     def get_one_imu(self, idx: int = 0) -> ImuMeasurement:
-        return next(islice(self.imu_iter(), idx, idx + 1))
+        return next(islice(self.imu(), idx, idx + 1))
 
-    def __str__(self):
-        return f"{self.name()}/{self.seq}"
+    def _fail_not_downloaded(self):
+        if not self.is_downloaded():
+            raise ValueError(
+                f"Data for {self} not found, please use `evalio download {self}` to download"
+            )
 
-    def __iter__(self) -> Iterator[Measurement]:
+    def __iter__(self) -> Iterator[Measurement]:  # type: ignore
+        self._fail_not_downloaded()
         return self.data_iter().__iter__()
 
-    def imu_iter(self) -> Iterable[ImuMeasurement]:
+    def imu(self) -> Iterable[ImuMeasurement]:
+        self._fail_not_downloaded()
         return self.data_iter().imu_iter()
 
-    def lidar_iter(self) -> Iterable[LidarMeasurement]:
+    def lidar(self) -> Iterable[LidarMeasurement]:
+        self._fail_not_downloaded()
         return self.data_iter().lidar_iter()
+
+    # ------------------------- Misc name helpers ------------------------- #
+    def __str__(self):
+        return self.full_name
+
+    @property
+    def seq_name(self) -> str:
+        return self.value
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.dataset_name}/{self.seq_name}"
+
+    @classmethod
+    def sequences(cls) -> list["Dataset"]:
+        return list(cls.__members__.values())
+
+    @property
+    def folder(self) -> Path:
+        return EVALIO_DATA / self.full_name
+
+
+class CharKinds(Enum):
+    LOWER = auto()
+    UPPER = auto()
+    DIGIT = auto()
+    OTHER = auto()
+
+    @staticmethod
+    def from_char(char: str):
+        if char.islower():
+            return CharKinds.LOWER
+        if char.isupper():
+            return CharKinds.UPPER
+        if char.isdigit():
+            return CharKinds.DIGIT
+        return CharKinds.OTHER
+
+
+def pascal_to_snake(identifier):
+    # only split when going from lower to something else
+    splits = []
+    last_kind = CharKinds.from_char(identifier[0])
+    for i, char in enumerate(identifier[1:], start=1):
+        kind = CharKinds.from_char(char)
+        if last_kind == CharKinds.LOWER and kind != CharKinds.LOWER:
+            splits.append(i)
+        last_kind = kind
+
+    parts = [identifier[i:j] for i, j in zip([0] + splits, splits + [None])]
+    return "_".join(parts).lower()
 
 
 def load_pose_csv(

--- a/python/evalio/datasets/botanic_garden.py
+++ b/python/evalio/datasets/botanic_garden.py
@@ -34,7 +34,7 @@ class BotanicGarden(Dataset):
     # ------------------------- For loading data ------------------------- #
     def data_iter(self) -> DatasetIterator:
         return RosbagIter(
-            self.folder / f"{self.seq_name}.bag",
+            self.folder / f"{self.seq_name[1:]}.bag",
             "/velodyne_points",
             "/imu/data",
             self.lidar_params(),
@@ -49,9 +49,9 @@ class BotanicGarden(Dataset):
 
     def ground_truth_raw(self) -> Trajectory:
         if self.seq_name == "1008_03":
-            filename = f"{self.seq_name}_gt_output.txt"
+            filename = f"{self.seq_name[1:]}_gt_output.txt"
         else:
-            filename = f"{self.seq_name}_GT_output.txt"
+            filename = f"{self.seq_name[1:]}_GT_output.txt"
 
         return load_pose_csv(
             self.folder / filename,
@@ -119,4 +119,8 @@ class BotanicGarden(Dataset):
         )
 
     def files(self) -> list[str]:
-        raise NotImplementedError
+        out = [f"{self.seq_name[1:]}.bag", f"{self.seq_name[1:]}_GT_output.txt"]
+        if self.seq_name == "1008_03":
+            out[1] = f"{self.seq_name[1:]}_gt_output.txt"
+
+        return out

--- a/python/evalio/datasets/botanic_garden.py
+++ b/python/evalio/datasets/botanic_garden.py
@@ -120,7 +120,7 @@ class BotanicGarden(Dataset):
 
     def files(self) -> list[str]:
         out = [f"{self.seq_name[1:]}.bag", f"{self.seq_name[1:]}_GT_output.txt"]
-        if self.seq_name == "1008_03":
+        if self.seq_name == "b1008_03":
             out[1] = f"{self.seq_name[1:]}_gt_output.txt"
 
         return out

--- a/python/evalio/datasets/enwide.py
+++ b/python/evalio/datasets/enwide.py
@@ -121,9 +121,36 @@ class EnWide(Dataset):
             max_range=100.0,
         )
 
+    @classmethod
+    def dataset_name(cls) -> str:
+        return "enwide"
+
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
+        return {
+            "intersection_s": [
+                "2023-08-09-16-19-09-intersection_s.bag",
+                "gt-intersection_s.csv",
+            ],
+            "runway_s": ["2023-08-09-18-44-24-runway_s.bag", "gt-runway_s.csv"],
+            "katzensee_s": [
+                "2023-08-21-10-20-22-katzensee_s.bag",
+                "gt-katzensee_s.csv",
+            ],
+            "runway_d": ["2023-08-09-18-52-05-runway_d.bag", "gt-runway_d.csv"],
+            "tunnel_d": ["2023-08-08-17-50-31-tunnel_d.bag", "gt-tunnel_d.csv"],
+            "field_d": ["2023-08-09-19-25-45-field_d.bag", "gt-field_d.csv"],
+            "katzensee_d": [
+                "2023-08-21-10-29-20-katzensee_d.bag",
+                "gt-katzensee_d.csv",
+            ],
+            "tunnel_s": ["2023-08-08-17-12-37-tunnel_s.bag", "gt-tunnel_s.csv"],
+            "intersection_d": [
+                "2023-08-09-17-58-11-intersection_d.bag",
+                "gt-intersection_d.csv",
+            ],
+            "field_s": ["2023-08-09-19-05-05-field_s.bag", "gt-field_s.csv"],
+        }[self.seq_name]
 
     def download(self):
         bag_date = {

--- a/python/evalio/datasets/helipr.py
+++ b/python/evalio/datasets/helipr.py
@@ -64,6 +64,7 @@ class HeLiPR(Dataset):
         return RawDataIter(
             lidar_iter(),
             imu_data.__iter__(),
+            len(lidar_stamps),
         )
 
     def ground_truth_raw(self) -> Trajectory:

--- a/python/evalio/datasets/helipr.py
+++ b/python/evalio/datasets/helipr.py
@@ -124,7 +124,7 @@ class HeLiPR(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
+        return ["Ouster", "Ouster_gt.txt", "xsens_imu.csv"]
 
     def download(self):
         id_gt = {

--- a/python/evalio/datasets/hilti_2022.py
+++ b/python/evalio/datasets/hilti_2022.py
@@ -52,7 +52,7 @@ class Hilti2022(Dataset):
 
     # ------------------------- For loading data ------------------------- #
     def data_iter(self) -> DatasetIterator:
-        bag, _ = self.get_files()
+        bag, _ = self.files()
         return RosbagIter(
             self.folder / bag,
             "/hesai/pandar",
@@ -68,7 +68,7 @@ class Hilti2022(Dataset):
 
     def ground_truth_raw(self) -> Trajectory:
         # TODO: Update the path to the ground truth file
-        _, gt = self.get_files()
+        _, gt = self.files()
         return load_pose_csv(
             self.folder / gt,
             ["sec", "x", "y", "z", "qx", "qy", "qz", "qw"],
@@ -114,9 +114,6 @@ class Hilti2022(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
-
-    def get_files(self) -> tuple[str, str]:
         filename = {
             "construction_upper_level_1": "exp04_construction_upper_level",
             "construction_upper_level_2": "exp05_construction_upper_level_2",
@@ -133,10 +130,10 @@ class Hilti2022(Dataset):
         if "construction" in self.seq_name:
             gt_file = "exp_" + gt_file[3:]
 
-        return bag_file, gt_file
+        return [bag_file, gt_file]
 
     def download(self):
-        bag_file, gt_file = self.get_files()
+        bag_file, gt_file = self.files()
 
         url = "https://tp-public-facing.s3.eu-north-1.amazonaws.com/Challenges/2022/"
 

--- a/python/evalio/datasets/hilti_2022.py
+++ b/python/evalio/datasets/hilti_2022.py
@@ -1,6 +1,6 @@
+from enum import auto
 import urllib
 import urllib.request
-from dataclasses import dataclass
 from pathlib import Path
 
 from evalio.datasets.iterators import (
@@ -16,7 +16,6 @@ import numpy as np
 from tqdm import tqdm
 
 from .base import (
-    EVALIO_DATA,
     SE3,
     SO3,
     Dataset,
@@ -43,13 +42,19 @@ def _urlretrieve(url: str, filename: Path, chunk_size: int = 1024 * 32) -> None:
                 pbar.update(len(chunk))
 
 
-@dataclass
 class Hilti2022(Dataset):
+    construction_upper_level_1 = auto()
+    construction_upper_level_2 = auto()
+    construction_upper_level_3 = auto()
+    basement_2 = auto()
+    attic_to_upper_gallery_2 = auto()
+    corridor_lower_gallery_2 = auto()
+
     # ------------------------- For loading data ------------------------- #
     def data_iter(self) -> DatasetIterator:
-        bag, _ = Hilti2022.get_files(self.seq)
+        bag, _ = self.get_files()
         return RosbagIter(
-            EVALIO_DATA / Hilti2022.name() / self.seq / bag,
+            self.folder / bag,
             "/hesai/pandar",
             "/alphasense/imu",
             self.lidar_params(),
@@ -63,9 +68,9 @@ class Hilti2022(Dataset):
 
     def ground_truth_raw(self) -> Trajectory:
         # TODO: Update the path to the ground truth file
-        _, gt = Hilti2022.get_files(self.seq)
+        _, gt = self.get_files()
         return load_pose_csv(
-            EVALIO_DATA / Hilti2022.name() / self.seq / gt,
+            self.folder / gt,
             ["sec", "x", "y", "z", "qx", "qy", "qz", "qw"],
             delimiter=" ",
         )
@@ -74,21 +79,6 @@ class Hilti2022(Dataset):
     @staticmethod
     def url() -> str:
         return "https://hilti-challenge.com/dataset-2022.html"
-
-    @staticmethod
-    def name() -> str:
-        return "hilti_2022"
-
-    @staticmethod
-    def sequences() -> list[str]:
-        return [
-            "construction_upper_level_1",
-            "construction_upper_level_2",
-            "construction_upper_level_3",
-            "basement_2",
-            "attic_to_upper_gallery_2",
-            "corridor_lower_gallery_2",
-        ]
 
     def imu_T_lidar(self) -> SE3:
         return SE3(
@@ -123,8 +113,10 @@ class Hilti2022(Dataset):
         )
 
     # ------------------------- For downloading ------------------------- #
-    @staticmethod
-    def get_files(seq: str) -> tuple[str, str]:
+    def files(self) -> list[str]:
+        raise NotImplementedError
+
+    def get_files(self) -> tuple[str, str]:
         filename = {
             "construction_upper_level_1": "exp04_construction_upper_level",
             "construction_upper_level_2": "exp05_construction_upper_level_2",
@@ -132,44 +124,27 @@ class Hilti2022(Dataset):
             "basement_2": "exp14_basement_2",
             "attic_to_upper_gallery_2": "exp16_attic_to_upper_gallery_2",
             "corridor_lower_gallery_2": "exp18_corridor_lower_gallery_2",
-        }[seq]
+        }[self.seq_name]
 
         bag_file = f"{filename}.bag"
         gt_file = f"{filename}_imu.txt"
 
         # Extra space in these ones for some reason
-        if "construction" in seq:
+        if "construction" in self.seq_name:
             gt_file = "exp_" + gt_file[3:]
 
         return bag_file, gt_file
 
-    @staticmethod
-    def check_download(seq: str) -> bool:
-        folder = EVALIO_DATA / Hilti2022.name() / seq
+    def download(self):
+        bag_file, gt_file = self.get_files()
 
-        bag_file, gt_file = Hilti2022.get_files(seq)
-
-        if not folder.exists():
-            return False
-        elif not (folder / gt_file).exists():
-            return False
-        elif not (folder / bag_file).exists():
-            return False
-        else:
-            return True
-
-    @staticmethod
-    def download(seq: str):
-        bag_file, gt_file = Hilti2022.get_files(seq)
-
-        folder = EVALIO_DATA / Hilti2022.name() / seq
         url = "https://tp-public-facing.s3.eu-north-1.amazonaws.com/Challenges/2022/"
 
-        print(f"Downloading to {folder}...")
-        folder.mkdir(parents=True, exist_ok=True)
-        if not (folder / gt_file).exists():
+        print(f"Downloading to {self.folder}...")
+        self.folder.mkdir(parents=True, exist_ok=True)
+        if not (self.folder / gt_file).exists():
             print(f"Downloading {gt_file}")
-            _urlretrieve(url + gt_file, folder / gt_file)
-        if not (folder / bag_file).exists():
+            _urlretrieve(url + gt_file, self.folder / gt_file)
+        if not (self.folder / bag_file).exists():
             print(f"Downloading {bag_file}")
-            _urlretrieve(url + bag_file, folder / bag_file)
+            _urlretrieve(url + bag_file, self.folder / bag_file)

--- a/python/evalio/datasets/iterators.py
+++ b/python/evalio/datasets/iterators.py
@@ -114,7 +114,6 @@ class RosbagIter(DatasetIterator):
             [x.msgcount for x in self.connections_lidar if x.topic == self.lidar_topic]
         )
 
-    # TODO: Formalize the lengths somehow?
     def __len__(self):
         return self.lidar_count
 
@@ -252,9 +251,11 @@ class RawDataIter(DatasetIterator):
         self,
         iter_lidar: Iterator[LidarMeasurement],
         iter_imu: Iterator[ImuMeasurement],
+        num_lidar: int,
     ):
         self.iter_lidar = iter_lidar
         self.iter_imu = iter_imu
+        self.num_lidar = num_lidar
         # These hold the current values for iteration to compare stamps on what should be returned
         self.next_lidar = None
         self.next_imu = None
@@ -264,6 +265,9 @@ class RawDataIter(DatasetIterator):
 
     def lidar_iter(self) -> Iterator[LidarMeasurement]:
         return self.iter_lidar
+
+    def __len__(self) -> int:
+        return self.num_lidar
 
     @staticmethod
     def _step(iter: Iterator[T]) -> Optional[T]:

--- a/python/evalio/datasets/multi_campus.py
+++ b/python/evalio/datasets/multi_campus.py
@@ -21,7 +21,7 @@ from .base import (
 )
 
 
-class MultiCampus2024(Dataset):
+class MultiCampus(Dataset):
     ntu_day_01 = auto()
     ntu_day_02 = auto()
     ntu_day_10 = auto()
@@ -183,7 +183,7 @@ class MultiCampus2024(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
+        return ["ouster.bag", "pose_inW.csv", "vectornav.bag"]
 
     def download(self):
         ouster_url = {
@@ -249,36 +249,12 @@ class MultiCampus2024(Dataset):
             "tuhh_night_09": "1xr5dTBydbjIhE42hNdELklruuhxgYkld",
         }[self.seq_name]
 
-        gt_spline_url = {
-            "ntu_day_01": "13PwhWOuIEJmaCtWY8JvZAJ-uTA4vcmV3",
-            "ntu_day_02": "19j_KBh8Tmfhi6DALY-soZDd90bsXy35X",
-            "ntu_day_10": "1AR0H2c3MYlU3qYMCrS6CuUlwJ0QkP2mJ",
-            "ntu_night_04": "1oOiSH6l6Au_9HNlw7wtKri_hKil8syJY",
-            "ntu_night_08": "1rNXsVACfYFGzApQVk4s0nJoau53Y6Kn5",
-            "ntu_night_13": "1uXqwSo_PqsqNQT4LC7-3p9OCSIeeWZQn",
-            "kth_day_06": "1omeDSQt5XowK4F9dM0ur5PSmjZfDrVgS",
-            "kth_day_09": "1ZkqJ9mmGhcbbkwHWoSNYoJP1TKw5ChXF",
-            "kth_day_10": "1lSQgTH4cgY77c-Mw7PGqxndOj7v7vhfg",
-            "kth_night_01": "15rKuojnx1apTA7C1XkzFLBkrY5jp_9gS",
-            "kth_night_04": "1X7i89QWFsl0UkYtIfJYBXXBz9exPAAeI",
-            "kth_night_05": "1tdHyg4tmFrJiP17cCP-cDaGcgS69G4Pg",
-            "tuhh_day_02": "1mWwXjk7rCOJytMH8809hrvy5i-wqnwoL",
-            "tuhh_day_03": "19rvvdCcE-o5bZr-1UGWXN9GBz4YHC7TX",
-            "tuhh_day_04": "1EXQI70rvFbJkvZ8Fww6PvcQxwJsJAo1W",
-            "tuhh_night_07": "1CIhyAK7bqwrdj3YoGWBc_AvtBDMY3pAi",
-            "tuhh_night_08": "1fWRpwboPgkk1KVrVKB_4Vu-nVe3YObuX",
-            "tuhh_night_09": "1ERnoR7Thtmsib6yu_4GACUODSyzyMLCk",
-        }[self.seq_name]
-
         import gdown  # type: ignore
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
 
         gdown.download(id=gt_url, output=str(self.folder / "pose_inW.csv"), resume=True)
-        gdown.download(
-            id=gt_spline_url, output=str(self.folder / "spline.csv"), resume=True
-        )
         gdown.download(
             id=ouster_url, output=str(self.folder / "ouster.bag"), resume=True
         )

--- a/python/evalio/datasets/multi_campus.py
+++ b/python/evalio/datasets/multi_campus.py
@@ -253,7 +253,7 @@ class MultiCampus(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
-
+        # TODO: Make these download without changing the filename
         gdown.download(id=gt_url, output=str(self.folder / "pose_inW.csv"), resume=True)
         gdown.download(
             id=ouster_url, output=str(self.folder / "ouster.bag"), resume=True

--- a/python/evalio/datasets/newer_college_2020.py
+++ b/python/evalio/datasets/newer_college_2020.py
@@ -100,12 +100,9 @@ class NewerCollege2020(Dataset):
     def files(self) -> list[str]:
         return {
             "dynamic_spinning": [
-                "ground_truth.csv",
                 "rooster_2020-07-10-09-23-18_0.bag",
             ],
             "short_experiment": [
-                "ground_truth.csv",
-                "imu_integration_results.pkl",
                 "rooster_2020-03-10-10-36-30_0.bag",
                 "rooster_2020-03-10-10-39-18_1.bag",
                 "rooster_2020-03-10-10-42-05_2.bag",
@@ -118,7 +115,6 @@ class NewerCollege2020(Dataset):
                 "rooster_2020-03-10-11-01-34_9.bag",
             ],
             "long_experiment": [
-                "ground_truth.csv",
                 "rooster_2020-03-10-11-36-51_0.bag",
                 "rooster_2020-03-10-11-39-38_1.bag",
                 "rooster_2020-03-10-11-42-25_2.bag",
@@ -137,18 +133,16 @@ class NewerCollege2020(Dataset):
                 "rooster_2020-03-10-12-18-36_15.bag",
             ],
             "quad_with_dynamics": [
-                "ground_truth.csv",
                 "rooster_2020-07-10-09-13-52_0.bag",
                 "rooster_2020-07-10-09-16-39_1.bag",
                 "rooster_2020-07-10-09-19-26_2.bag",
             ],
             "parkland_mound": [
-                "ground_truth.csv",
                 "rooster_2020-07-10-09-31-24_0.bag",
                 "rooster_2020-07-10-09-34-11_1.bag",
                 "rooster_2020-07-10-09-36-58_2.bag",
             ],
-        }[self.seq_name]
+        }[self.seq_name] + ["ground_truth.csv"]
 
     def download(self):
         folder_id = {

--- a/python/evalio/datasets/newer_college_2020.py
+++ b/python/evalio/datasets/newer_college_2020.py
@@ -165,7 +165,6 @@ class NewerCollege2020(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
-        gdown.download(
-            id=gt_url, output=str(self.folder / "ground_truth.csv"), resume=True
-        )
+        # TODO: Make this download to an identical name as it is online
+        gdown.download(id=gt_url, output=self.folder, resume=True)
         gdown.download_folder(id=folder_id, output=str(self.folder), resume=True)

--- a/python/evalio/datasets/newer_college_2021.py
+++ b/python/evalio/datasets/newer_college_2021.py
@@ -99,7 +99,45 @@ class NewerCollege2021(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
+        return {
+            "cloister": [
+                "2021-12-02-10-15-59_0-cloister.bag",
+                "2021-12-02-10-19-05_1-cloister.bag",
+            ],
+            "maths_medium": [
+                "2021-04-07-13-55-18-math-medium.bag",
+            ],
+            "quad_medium": [
+                "2021-07-01-11-31-35_0-quad-medium.bag",
+            ],
+            "maths-hard": [
+                "2021-04-07-13-58-54_0-math-hard.bag",
+                "2021-04-07-14-02-18_1-math-hard.bag",
+            ],
+            "quad_hard": [
+                "2021-07-01-11-35-14_0-quad-hard.bag",
+            ],
+            "quad_easy": [
+                "2021-07-01-10-37-38-quad-easy.bag",
+            ],
+            "park": [
+                "2021-11-30-17-09-49_0-park.bag",
+                "2021-11-30-17-13-13_1-park.bag",
+                "2021-11-30-17-16-38_2-park.bag",
+                "2021-11-30-17-20-07_3-park.bag",
+                "2021-11-30-17-23-25_4-park.bag",
+                "2021-11-30-17-26-36_5-park.bag",
+                "2021-11-30-17-30-06_6-park.bag",
+                "2021-11-30-17-33-19_7-park.bag",
+            ],
+            "maths_easy": [
+                "2021-04-07-13-49-03_0-math-easy.bag",
+                "2021-04-07-13-52-31_1-math-easy.bag",
+            ],
+            "stairs": [
+                "2021-07-01-10-40-50_0-stairs.bag",
+            ],
+        }[self.seq_name] + ["ground_truth.csv"]
 
     def download(self):
         # TODO:

--- a/python/evalio/datasets/newer_college_2021.py
+++ b/python/evalio/datasets/newer_college_2021.py
@@ -110,7 +110,7 @@ class NewerCollege2021(Dataset):
             "quad_medium": [
                 "2021-07-01-11-31-35_0-quad-medium.bag",
             ],
-            "maths-hard": [
+            "maths_hard": [
                 "2021-04-07-13-58-54_0-math-hard.bag",
                 "2021-04-07-14-02-18_1-math-hard.bag",
             ],
@@ -187,6 +187,7 @@ class NewerCollege2021(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
+        # TODO: Make this download to matching name as online
         gdown.download(
             id=gt_ids, output=str(self.folder / "ground_truth.csv"), resume=True
         )

--- a/python/evalio/datasets/oxford_spires.py
+++ b/python/evalio/datasets/oxford_spires.py
@@ -140,7 +140,73 @@ class OxfordSpires(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        raise NotImplementedError
+        return {
+            "christ_church_02": [
+                "1710754066_2024-03-18-09-27-47_0",
+                "1710754066_2024-03-18-09-36-49_1",
+                "gt-tum.csv",
+            ],
+            "blenheim_palace_01": [
+                "1710406700_2024-03-14-08-58-21_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "christ_church_05": [
+                "1710926317_2024-03-20-09-18-38_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "keble_college_03": [
+                "1710256011_2024-03-12-15-06-52_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "christ_church_01": [
+                "1710752531_2024-03-18-09-02-12_0",
+                "1710752531_2024-03-18-09-11-55_1",
+                "gt-tum.csv",
+            ],
+            "bodleian_library_02": [
+                "1716183690_2024-05-20-06-41-31_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "blenheim_palace_02": [
+                "1710407340_2024-03-14-09-09-01_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "keble_college_04": [
+                "1710256650_2024-03-12-15-17-31_0",
+                "1710256650_2024-03-12-15-26-05_1",
+                "gt-tum.csv",
+            ],
+            "observatory_quarter_01": [
+                "1710338090_2024-03-13-13-54-51_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "christ_church_03": [
+                "1710755015_2024-03-18-09-43-36_0_blurred_filtered.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "blenheim_palace_05": [
+                "1710410169_2024-03-14-09-56-09_0_blurred_filtered.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "observatory_quarter_02": [
+                "1710338490_2024-03-13-14-01-30_blurred_filtered.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+            "keble_college_02": [
+                "1710255615_2024-03-12-15-00-16_0_blurred_filtered_compressed.db3",
+                "gt-tum.csv",
+                "metadata.yaml",
+            ],
+        }[self.seq_name]
 
     def download(self):
         folder_id = {

--- a/tests/get_files.py
+++ b/tests/get_files.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+# Helper script to return all files that are included in a dataset
+# Easier than manually checking each
+dir = Path("/media/contagon/Aquatonomy/evalio/newer_college_2020")
+results = {}
+for seq in dir.iterdir():
+    results[seq.stem] = sorted([file.name for file in seq.iterdir()])
+
+print(results)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+from evalio.cli.ls import ls
+from evalio.cli.parser import DatasetBuilder
+
+
+def test_ls_pipelines():
+    ls("datasets")
+    ls("pipelines")
+
+
+def test_dataset_build():
+    all_datasets, all_names = map(
+        list,
+        zip(
+            *[
+                (s, s.full_name)
+                for d in DatasetBuilder._all_datasets().values()
+                for s in d.sequences()
+            ]
+        ),
+    )
+
+    # Test all datasets
+    out = [d.dataset for d in DatasetBuilder.parse(all_names)]
+    if out != all_datasets:
+        assert len(out) == len(all_datasets), f"Missing datasets in parser {all_names}"
+        for d, name in zip(out, all_names):
+            assert out == d, f"Failed on {name}"

--- a/tests/test_dataset_impl.py
+++ b/tests/test_dataset_impl.py
@@ -1,0 +1,25 @@
+from evalio.cli.parser import DatasetBuilder
+from evalio.datasets import Dataset
+import pytest
+
+datasets = DatasetBuilder._all_datasets().values()
+
+
+# Test to ensure all datasets implement the required attributes
+@pytest.mark.parametrize("dataset", datasets)
+def test_impl(dataset):
+    attrs = [
+        "data_iter",
+        "ground_truth_raw",
+        "url",
+        "imu_T_lidar",
+        "imu_T_gt",
+        "imu_params",
+        "lidar_params",
+        "files",
+    ]
+
+    for a in attrs:
+        assert getattr(dataset, a) != getattr(
+            Dataset, a
+        ), f"{dataset} should implement {a}"

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -10,12 +10,12 @@ from utils import check_lidar_eq
 data_dir = Path("tests/data")
 dataset_classes = DatasetBuilder._all_datasets()
 datasets = [
-    cls(cls.sequences()[0])
+    cls.sequences()[0]
     for cls in dataset_classes.values()
     if (
-        cls.check_download(cls.sequences()[0])
-        and (data_dir / f"imu_{cls.name()}.pkl").exists()
-        and (data_dir / f"lidar_{cls.name()}.pkl").exists()
+        cls.sequences()[0].is_downloaded()
+        and (data_dir / f"imu_{cls.dataset_name()}.pkl").exists()
+        and (data_dir / f"lidar_{cls.dataset_name()}.pkl").exists()
     )
 ]
 
@@ -23,16 +23,18 @@ datasets = [
 @pytest.mark.parametrize("dataset", datasets)
 def test_load_imu(dataset: Dataset):
     imu = dataset.get_one_imu()
-    with open(data_dir / f"imu_{dataset.name()}.pkl", "rb") as f:
+    with open(data_dir / f"imu_{dataset.dataset_name()}.pkl", "rb") as f:
         imu_cached: ImuMeasurement = pickle.load(f)
 
-    assert imu == imu_cached, f"IMU measurements do not match for {dataset.name()}"
+    assert (
+        imu == imu_cached
+    ), f"IMU measurements do not match for {dataset.dataset_name()}"
 
 
 @pytest.mark.parametrize("dataset", datasets)
 def test_load_lidar(dataset: Dataset):
     lidar = dataset.get_one_lidar()
-    with open(data_dir / f"lidar_{dataset.name()}.pkl", "rb") as f:
+    with open(data_dir / f"lidar_{dataset.dataset_name()}.pkl", "rb") as f:
         lidar_cached: LidarMeasurement = pickle.load(f)
 
     check_lidar_eq(lidar, lidar_cached)

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -34,7 +34,7 @@ def make_lidars(num: int = 10) -> list[LidarMeasurement]:
 def test_rawdata():
     imus = make_imus()
     lidars = make_lidars()
-    iterator = RawDataIter(iter(lidars), iter(imus))
+    iterator = RawDataIter(iter(lidars), iter(imus), len(lidars))
 
     last_stamp = Stamp.from_sec(0.0)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,5 @@
 version = 1
-requires-python = ">=3.10"
-resolution-markers = [
-    "python_full_version < '3.13'",
-    "python_full_version >= '3.13'",
-]
+requires-python = ">=3.11"
 
 [[package]]
 name = "argcomplete"
@@ -53,18 +49,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/07/f44ca684db4e4f08a3fdc6eeb9a0d15dc6883efc7b8c90357fdbf74e186c/cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14", size = 182191 },
-    { url = "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67", size = 178592 },
-    { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024 },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188 },
-    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571 },
-    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687 },
-    { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211 },
-    { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325 },
-    { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784 },
-    { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564 },
-    { url = "https://files.pythonhosted.org/packages/f8/fe/4d41c2f200c4a457933dbd98d3cf4e911870877bd94d9656cc0fcb390681/cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c", size = 171804 },
-    { url = "https://files.pythonhosted.org/packages/d1/b6/0b0f5ab93b0df4acc49cae758c81fe4e5ef26c3ae2e10cc69249dfd8b3ab/cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15", size = 181299 },
     { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264 },
     { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651 },
     { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259 },
@@ -107,21 +91,6 @@ version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5", size = 104809 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/61/095a0aa1a84d1481998b534177c8566fdc50bb1233ea9a0478cd3cc075bd/charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3", size = 194219 },
-    { url = "https://files.pythonhosted.org/packages/cc/94/f7cf5e5134175de79ad2059edf2adce18e0685ebdb9227ff0139975d0e93/charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027", size = 122521 },
-    { url = "https://files.pythonhosted.org/packages/46/6a/d5c26c41c49b546860cc1acabdddf48b0b3fb2685f4f5617ac59261b44ae/charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03", size = 120383 },
-    { url = "https://files.pythonhosted.org/packages/b8/60/e2f67915a51be59d4539ed189eb0a2b0d292bf79270410746becb32bc2c3/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d", size = 138223 },
-    { url = "https://files.pythonhosted.org/packages/05/8c/eb854996d5fef5e4f33ad56927ad053d04dc820e4a3d39023f35cad72617/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e", size = 148101 },
-    { url = "https://files.pythonhosted.org/packages/f6/93/bb6cbeec3bf9da9b2eba458c15966658d1daa8b982c642f81c93ad9b40e1/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6", size = 140699 },
-    { url = "https://files.pythonhosted.org/packages/da/f1/3702ba2a7470666a62fd81c58a4c40be00670e5006a67f4d626e57f013ae/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5", size = 142065 },
-    { url = "https://files.pythonhosted.org/packages/3f/ba/3f5e7be00b215fa10e13d64b1f6237eb6ebea66676a41b2bcdd09fe74323/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537", size = 144505 },
-    { url = "https://files.pythonhosted.org/packages/33/c3/3b96a435c5109dd5b6adc8a59ba1d678b302a97938f032e3770cc84cd354/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c", size = 139425 },
-    { url = "https://files.pythonhosted.org/packages/43/05/3bf613e719efe68fb3a77f9c536a389f35b95d75424b96b426a47a45ef1d/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12", size = 145287 },
-    { url = "https://files.pythonhosted.org/packages/58/78/a0bc646900994df12e07b4ae5c713f2b3e5998f58b9d3720cce2aa45652f/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f", size = 149929 },
-    { url = "https://files.pythonhosted.org/packages/eb/5c/97d97248af4920bc68687d9c3b3c0f47c910e21a8ff80af4565a576bd2f0/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269", size = 141605 },
-    { url = "https://files.pythonhosted.org/packages/a8/31/47d018ef89f95b8aded95c589a77c072c55e94b50a41aa99c0a2008a45a4/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519", size = 142646 },
-    { url = "https://files.pythonhosted.org/packages/ae/d5/4fecf1d58bedb1340a50f165ba1c7ddc0400252d6832ff619c4568b36cc0/charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73", size = 92846 },
-    { url = "https://files.pythonhosted.org/packages/a2/a0/4af29e22cb5942488cf45630cbdd7cefd908768e69bdd90280842e4e8529/charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09", size = 100343 },
     { url = "https://files.pythonhosted.org/packages/68/77/02839016f6fbbf808e8b38601df6e0e66c17bbab76dff4613f7511413597/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db", size = 191647 },
     { url = "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96", size = 121434 },
     { url = "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e", size = 118979 },
@@ -259,15 +228,6 @@ dev = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
-]
-
-[[package]]
 name = "filelock"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -315,13 +275,6 @@ version = "4.3.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a4/31/ec1259ca8ad11568abaf090a7da719616ca96b60d097ccc5799cd0ff599c/lz4-4.3.3.tar.gz", hash = "sha256:01fe674ef2889dbb9899d8a67361e0c4a2c833af5aeb37dd505727cf5d2a131e", size = 171509 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/53/61258b5effac76dea5768b07042b2c3c56e15a91194cef92284a0dc0f5e7/lz4-4.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b891880c187e96339474af2a3b2bfb11a8e4732ff5034be919aa9029484cd201", size = 254266 },
-    { url = "https://files.pythonhosted.org/packages/92/84/c243a5515950d72ff04220fd49903801825e4ac23691e19e7082d9d9f94b/lz4-4.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:222a7e35137d7539c9c33bb53fcbb26510c5748779364014235afc62b0ec797f", size = 212359 },
-    { url = "https://files.pythonhosted.org/packages/10/26/5287564a909d069fdd6c25f2f420c58c5758993fa3ad2e064a7b610e6e5f/lz4-4.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f76176492ff082657ada0d0f10c794b6da5800249ef1692b35cf49b1e93e8ef7", size = 1237799 },
-    { url = "https://files.pythonhosted.org/packages/cf/50/75c8f966dbcc524e7253f99b8e04c6cad7328f517eb0323abf8b4068f5bb/lz4-4.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1d18718f9d78182c6b60f568c9a9cec8a7204d7cb6fad4e511a2ef279e4cb05", size = 1263957 },
-    { url = "https://files.pythonhosted.org/packages/91/54/0f61c77a9599beb14ac5b828e8da20a04c6eaadb4f3fdbd79a817c66eb74/lz4-4.3.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6cdc60e21ec70266947a48839b437d46025076eb4b12c76bd47f8e5eb8a75dcc", size = 1184035 },
-    { url = "https://files.pythonhosted.org/packages/8e/84/3be7fad87d84b67cd43174d67fc567e0aa3be154f8b0a1c2c0ff8df30854/lz4-4.3.3-cp310-cp310-win32.whl", hash = "sha256:c81703b12475da73a5d66618856d04b1307e43428a7e59d98cfe5a5d608a74c6", size = 87235 },
-    { url = "https://files.pythonhosted.org/packages/21/08/dc4714eb771b502deec8a714e40e5fbd2242bacd5fe55dcd29a0cb35c567/lz4-4.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:43cf03059c0f941b772c8aeb42a0813d68d7081c009542301637e5782f8a33e2", size = 99781 },
     { url = "https://files.pythonhosted.org/packages/f9/f7/cfb942edd53c8a6aba168720ccf3d6a0cac3e891a7feba97d5823b5dd047/lz4-4.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30e8c20b8857adef7be045c65f47ab1e2c4fabba86a9fa9a997d7674a31ea6b6", size = 254267 },
     { url = "https://files.pythonhosted.org/packages/71/ca/046bd7e7e1ed4639eb398192374bc3fbf5010d3c168361fec161b63e8bfa/lz4-4.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2f7b1839f795315e480fb87d9bc60b186a98e3e5d17203c6e757611ef7dcef61", size = 212353 },
     { url = "https://files.pythonhosted.org/packages/0c/c2/5beb6a7bb7fd27cd5fe5bb93c15636d30987794b161e4609fbf20dc3b5c7/lz4-4.3.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edfd858985c23523f4e5a7526ca6ee65ff930207a7ec8a8f57a01eae506aaee7", size = 1239095 },
@@ -344,14 +297,6 @@ version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468 },
-    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411 },
-    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016 },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889 },
-    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746 },
-    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620 },
-    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659 },
-    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905 },
     { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554 },
     { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127 },
     { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994 },
@@ -397,17 +342,6 @@ version = "10.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/69/a31cccd538ca0b5272be2a38347f8839b97a14be104ea08b0db92f749c74/pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e", size = 3509271 },
-    { url = "https://files.pythonhosted.org/packages/9a/9e/4143b907be8ea0bce215f2ae4f7480027473f8b61fcedfda9d851082a5d2/pillow-10.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d", size = 3375658 },
-    { url = "https://files.pythonhosted.org/packages/8a/25/1fc45761955f9359b1169aa75e241551e74ac01a09f487adaaf4c3472d11/pillow-10.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856", size = 4332075 },
-    { url = "https://files.pythonhosted.org/packages/5e/dd/425b95d0151e1d6c951f45051112394f130df3da67363b6bc75dc4c27aba/pillow-10.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f", size = 4444808 },
-    { url = "https://files.pythonhosted.org/packages/b1/84/9a15cc5726cbbfe7f9f90bfb11f5d028586595907cd093815ca6644932e3/pillow-10.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b", size = 4356290 },
-    { url = "https://files.pythonhosted.org/packages/b5/5b/6651c288b08df3b8c1e2f8c1152201e0b25d240e22ddade0f1e242fc9fa0/pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc", size = 4525163 },
-    { url = "https://files.pythonhosted.org/packages/07/8b/34854bf11a83c248505c8cb0fcf8d3d0b459a2246c8809b967963b6b12ae/pillow-10.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e", size = 4463100 },
-    { url = "https://files.pythonhosted.org/packages/78/63/0632aee4e82476d9cbe5200c0cdf9ba41ee04ed77887432845264d81116d/pillow-10.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46", size = 4592880 },
-    { url = "https://files.pythonhosted.org/packages/df/56/b8663d7520671b4398b9d97e1ed9f583d4afcbefbda3c6188325e8c297bd/pillow-10.4.0-cp310-cp310-win32.whl", hash = "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984", size = 2235218 },
-    { url = "https://files.pythonhosted.org/packages/f4/72/0203e94a91ddb4a9d5238434ae6c1ca10e610e8487036132ea9bf806ca2a/pillow-10.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141", size = 2554487 },
-    { url = "https://files.pythonhosted.org/packages/bd/52/7e7e93d7a6e4290543f17dc6f7d3af4bd0b3dd9926e2e8a35ac2282bc5f4/pillow-10.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1", size = 2243219 },
     { url = "https://files.pythonhosted.org/packages/a7/62/c9449f9c3043c37f73e7487ec4ef0c03eb9c9afc91a92b977a67b3c0bbc5/pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c", size = 3509265 },
     { url = "https://files.pythonhosted.org/packages/f4/5f/491dafc7bbf5a3cc1845dc0430872e8096eb9e2b6f8161509d124594ec2d/pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be", size = 3375655 },
     { url = "https://files.pythonhosted.org/packages/73/d5/c4011a76f4207a3c151134cd22a1415741e42fa5ddecec7c0182887deb3d/pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3", size = 4340304 },
@@ -441,13 +375,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/f9/cfaa5082ca9bc4a6de66ffe1c12c2d90bf09c309a5f52b27759a596900e7/pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060", size = 2235603 },
     { url = "https://files.pythonhosted.org/packages/01/6a/30ff0eef6e0c0e71e55ded56a38d4859bf9d3634a94a88743897b5f96936/pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea", size = 2554972 },
     { url = "https://files.pythonhosted.org/packages/48/2c/2e0a52890f269435eee38b21c8218e102c621fe8d8df8b9dd06fabf879ba/pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d", size = 2243375 },
-    { url = "https://files.pythonhosted.org/packages/38/30/095d4f55f3a053392f75e2eae45eba3228452783bab3d9a920b951ac495c/pillow-10.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4", size = 3493889 },
-    { url = "https://files.pythonhosted.org/packages/f3/e8/4ff79788803a5fcd5dc35efdc9386af153569853767bff74540725b45863/pillow-10.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da", size = 3346160 },
-    { url = "https://files.pythonhosted.org/packages/d7/ac/4184edd511b14f760c73f5bb8a5d6fd85c591c8aff7c2229677a355c4179/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026", size = 3435020 },
-    { url = "https://files.pythonhosted.org/packages/da/21/1749cd09160149c0a246a81d646e05f35041619ce76f6493d6a96e8d1103/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e", size = 3490539 },
-    { url = "https://files.pythonhosted.org/packages/b6/f5/f71fe1888b96083b3f6dfa0709101f61fc9e972c0c8d04e9d93ccef2a045/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5", size = 3476125 },
-    { url = "https://files.pythonhosted.org/packages/96/b9/c0362c54290a31866c3526848583a2f45a535aa9d725fd31e25d318c805f/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885", size = 3579373 },
-    { url = "https://files.pythonhosted.org/packages/52/3b/ce7a01026a7cf46e5452afa86f97a5e88ca97f562cafa76570178ab56d8d/pillow-10.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5", size = 2554661 },
 ]
 
 [[package]]
@@ -468,13 +395,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/4e/ea6d43f324169f8aec0e57569443a38bab4b398d09769ca64f7b4d467de3/pyarrow-17.0.0.tar.gz", hash = "sha256:4beca9521ed2c0921c1023e68d097d0299b62c362639ea315572a58f3f50fd28", size = 1112479 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/5d/78d4b040bc5ff2fc6c3d03e80fca396b742f6c125b8af06bcf7427f931bc/pyarrow-17.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:a5c8b238d47e48812ee577ee20c9a2779e6a5904f1708ae240f53ecbee7c9f07", size = 28994846 },
-    { url = "https://files.pythonhosted.org/packages/3b/73/8ed168db7642e91180330e4ea9f3ff8bab404678f00d32d7df0871a4933b/pyarrow-17.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:db023dc4c6cae1015de9e198d41250688383c3f9af8f565370ab2b4cb5f62655", size = 27165908 },
-    { url = "https://files.pythonhosted.org/packages/81/36/e78c24be99242063f6d0590ef68c857ea07bdea470242c361e9a15bd57a4/pyarrow-17.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da1e060b3876faa11cee287839f9cc7cdc00649f475714b8680a05fd9071d545", size = 39264209 },
-    { url = "https://files.pythonhosted.org/packages/18/4c/3db637d7578f683b0a8fb8999b436bdbedd6e3517bd4f90c70853cf3ad20/pyarrow-17.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c06d4624c0ad6674364bb46ef38c3132768139ddec1c56582dbac54f2663e2", size = 39862883 },
-    { url = "https://files.pythonhosted.org/packages/81/3c/0580626896c842614a523e66b351181ed5bb14e5dfc263cd68cea2c46d90/pyarrow-17.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:fa3c246cc58cb5a4a5cb407a18f193354ea47dd0648194e6265bd24177982fe8", size = 38723009 },
-    { url = "https://files.pythonhosted.org/packages/ee/fb/c1b47f0ada36d856a352da261a44d7344d8f22e2f7db3945f8c3b81be5dd/pyarrow-17.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f7ae2de664e0b158d1607699a16a488de3d008ba99b3a7aa5de1cbc13574d047", size = 39855626 },
-    { url = "https://files.pythonhosted.org/packages/19/09/b0a02908180a25d57312ab5919069c39fddf30602568980419f4b02393f6/pyarrow-17.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:5984f416552eea15fd9cee03da53542bf4cddaef5afecefb9aa8d1010c335087", size = 25147242 },
     { url = "https://files.pythonhosted.org/packages/f9/46/ce89f87c2936f5bb9d879473b9663ce7a4b1f4359acc2f0eb39865eaa1af/pyarrow-17.0.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:1c8856e2ef09eb87ecf937104aacfa0708f22dfeb039c363ec99735190ffb977", size = 29028748 },
     { url = "https://files.pythonhosted.org/packages/8d/8e/ce2e9b2146de422f6638333c01903140e9ada244a2a477918a368306c64c/pyarrow-17.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e19f569567efcbbd42084e87f948778eb371d308e137a0f97afe19bb860ccb3", size = 27190965 },
     { url = "https://files.pythonhosted.org/packages/3b/c8/5675719570eb1acd809481c6d64e2136ffb340bc387f4ca62dce79516cea/pyarrow-17.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b244dc8e08a23b3e352899a006a26ae7b4d0da7bb636872fa8f5884e70acf15", size = 39269081 },
@@ -524,11 +444,9 @@ version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
@@ -541,15 +459,6 @@ version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199 },
-    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758 },
-    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463 },
-    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280 },
-    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239 },
-    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802 },
-    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527 },
-    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052 },
-    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774 },
     { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
     { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
     { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
@@ -652,14 +561,6 @@ version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/ab/bab9eb1566cd16f060b54055dd39cf6a34bfa0240c53a7218c43e974295b/ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512", size = 213824 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/01/37ac131614f71b98e9b148b2d7790662dcee92217d2fb4bac1aa377def33/ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d", size = 148236 },
-    { url = "https://files.pythonhosted.org/packages/61/ee/4874c9fc96010fce85abefdcbe770650c5324288e988d7a48b527a423815/ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462", size = 133996 },
-    { url = "https://files.pythonhosted.org/packages/d3/62/c60b034d9a008bbd566eeecf53a5a4c73d191c8de261290db6761802b72d/ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412", size = 526680 },
-    { url = "https://files.pythonhosted.org/packages/90/8c/6cdb44f548b29eb6328b9e7e175696336bc856de2ff82e5776f860f03822/ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f", size = 605853 },
-    { url = "https://files.pythonhosted.org/packages/88/30/fc45b45d5eaf2ff36cffd215a2f85e9b90ac04e70b97fd4097017abfb567/ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334", size = 655206 },
-    { url = "https://files.pythonhosted.org/packages/af/dc/133547f90f744a0c827bac5411d84d4e81da640deb3af1459e38c5f3b6a0/ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d", size = 689649 },
-    { url = "https://files.pythonhosted.org/packages/23/1d/589139191b187a3c750ae8d983c42fd799246d5f0dd84451a0575c9bdbe9/ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d", size = 100044 },
-    { url = "https://files.pythonhosted.org/packages/4f/5b/744df20285a75ac4c606452ce9a0fcc42087d122f42294518ded1017697c/ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31", size = 117825 },
     { url = "https://files.pythonhosted.org/packages/b1/15/971b385c098e8d0d170893f5ba558452bb7b776a0c90658b8f4dd0e3382b/ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069", size = 148870 },
     { url = "https://files.pythonhosted.org/packages/01/b0/4ddef56e9f703d7909febc3a421d709a3482cda25826816ec595b73e3847/ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248", size = 134475 },
     { url = "https://files.pythonhosted.org/packages/a4/f7/22d6b620ed895a05d40802d8281eff924dc6190f682d933d4efff60db3b5/ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b", size = 544020 },
@@ -712,15 +613,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/b9/31ba9cd990e626574baf93fbc1ac61cf9ed54faafd04c479117517661637/scipy-1.15.2.tar.gz", hash = "sha256:cd58a314d92838f7e6f755c8a2167ead4f27e1fd5c1251fd54289569ef3495ec", size = 59417316 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/df/ef233fff6838fe6f7840d69b5ef9f20d2b5c912a8727b21ebf876cb15d54/scipy-1.15.2-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a2ec871edaa863e8213ea5df811cd600734f6400b4af272e1c011e69401218e9", size = 38692502 },
-    { url = "https://files.pythonhosted.org/packages/5c/20/acdd4efb8a68b842968f7bc5611b1aeb819794508771ad104de418701422/scipy-1.15.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:6f223753c6ea76983af380787611ae1291e3ceb23917393079dcc746ba60cfb5", size = 30085508 },
-    { url = "https://files.pythonhosted.org/packages/42/55/39cf96ca7126f1e78ee72a6344ebdc6702fc47d037319ad93221063e6cf4/scipy-1.15.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ecf797d2d798cf7c838c6d98321061eb3e72a74710e6c40540f0e8087e3b499e", size = 22359166 },
-    { url = "https://files.pythonhosted.org/packages/51/48/708d26a4ab8a1441536bf2dfcad1df0ca14a69f010fba3ccbdfc02df7185/scipy-1.15.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:9b18aa747da280664642997e65aab1dd19d0c3d17068a04b3fe34e2559196cb9", size = 25112047 },
-    { url = "https://files.pythonhosted.org/packages/dd/65/f9c5755b995ad892020381b8ae11f16d18616208e388621dfacc11df6de6/scipy-1.15.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87994da02e73549dfecaed9e09a4f9d58a045a053865679aeb8d6d43747d4df3", size = 35536214 },
-    { url = "https://files.pythonhosted.org/packages/de/3c/c96d904b9892beec978562f64d8cc43f9cca0842e65bd3cd1b7f7389b0ba/scipy-1.15.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69ea6e56d00977f355c0f84eba69877b6df084516c602d93a33812aa04d90a3d", size = 37646981 },
-    { url = "https://files.pythonhosted.org/packages/3d/74/c2d8a24d18acdeae69ed02e132b9bc1bb67b7bee90feee1afe05a68f9d67/scipy-1.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:888307125ea0c4466287191e5606a2c910963405ce9671448ff9c81c53f85f58", size = 37230048 },
-    { url = "https://files.pythonhosted.org/packages/42/19/0aa4ce80eca82d487987eff0bc754f014dec10d20de2f66754fa4ea70204/scipy-1.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9412f5e408b397ff5641080ed1e798623dbe1ec0d78e72c9eca8992976fa65aa", size = 40010322 },
-    { url = "https://files.pythonhosted.org/packages/d0/d2/f0683b7e992be44d1475cc144d1f1eeae63c73a14f862974b4db64af635e/scipy-1.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:b5e025e903b4f166ea03b109bb241355b9c42c279ea694d8864d033727205e65", size = 41233385 },
     { url = "https://files.pythonhosted.org/packages/40/1f/bf0a5f338bda7c35c08b4ed0df797e7bafe8a78a97275e9f439aceb46193/scipy-1.15.2-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:92233b2df6938147be6fa8824b8136f29a18f016ecde986666be5f4d686a91a4", size = 38703651 },
     { url = "https://files.pythonhosted.org/packages/de/54/db126aad3874601048c2c20ae3d8a433dbfd7ba8381551e6f62606d9bd8e/scipy-1.15.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:62ca1ff3eb513e09ed17a5736929429189adf16d2d740f44e53270cc800ecff1", size = 30102038 },
     { url = "https://files.pythonhosted.org/packages/61/d8/84da3fffefb6c7d5a16968fe5b9f24c98606b165bb801bb0b8bc3985200f/scipy-1.15.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4c6676490ad76d1c2894d77f976144b41bd1a4052107902238047fb6a473e971", size = 22375518 },
@@ -790,15 +682,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f", size = 15164 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", size = 12757 },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
@@ -864,22 +747,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz", hash = "sha256:b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09", size = 681701 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/55/bd0487e86679db1823fc9ee0d8c9c78ae2413d34c0b461193b5f4c31d22f/zstandard-0.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf0a05b6059c0528477fba9054d09179beb63744355cab9f38059548fedd46a9", size = 788701 },
-    { url = "https://files.pythonhosted.org/packages/e1/8a/ccb516b684f3ad987dfee27570d635822e3038645b1a950c5e8022df1145/zstandard-0.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc9ca1c9718cb3b06634c7c8dec57d24e9438b2aa9a0f02b8bb36bf478538880", size = 633678 },
-    { url = "https://files.pythonhosted.org/packages/12/89/75e633d0611c028e0d9af6df199423bf43f54bea5007e6718ab7132e234c/zstandard-0.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77da4c6bfa20dd5ea25cbf12c76f181a8e8cd7ea231c673828d0386b1740b8dc", size = 4941098 },
-    { url = "https://files.pythonhosted.org/packages/4a/7a/bd7f6a21802de358b63f1ee636ab823711c25ce043a3e9f043b4fcb5ba32/zstandard-0.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2170c7e0367dde86a2647ed5b6f57394ea7f53545746104c6b09fc1f4223573", size = 5308798 },
-    { url = "https://files.pythonhosted.org/packages/79/3b/775f851a4a65013e88ca559c8ae42ac1352db6fcd96b028d0df4d7d1d7b4/zstandard-0.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c16842b846a8d2a145223f520b7e18b57c8f476924bda92aeee3a88d11cfc391", size = 5341840 },
-    { url = "https://files.pythonhosted.org/packages/09/4f/0cc49570141dd72d4d95dd6fcf09328d1b702c47a6ec12fbed3b8aed18a5/zstandard-0.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:157e89ceb4054029a289fb504c98c6a9fe8010f1680de0201b3eb5dc20aa6d9e", size = 5440337 },
-    { url = "https://files.pythonhosted.org/packages/e7/7c/aaa7cd27148bae2dc095191529c0570d16058c54c4597a7d118de4b21676/zstandard-0.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:203d236f4c94cd8379d1ea61db2fce20730b4c38d7f1c34506a31b34edc87bdd", size = 4861182 },
-    { url = "https://files.pythonhosted.org/packages/ac/eb/4b58b5c071d177f7dc027129d20bd2a44161faca6592a67f8fcb0b88b3ae/zstandard-0.23.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dc5d1a49d3f8262be192589a4b72f0d03b72dcf46c51ad5852a4fdc67be7b9e4", size = 4932936 },
-    { url = "https://files.pythonhosted.org/packages/44/f9/21a5fb9bb7c9a274b05ad700a82ad22ce82f7ef0f485980a1e98ed6e8c5f/zstandard-0.23.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:752bf8a74412b9892f4e5b58f2f890a039f57037f52c89a740757ebd807f33ea", size = 5464705 },
-    { url = "https://files.pythonhosted.org/packages/49/74/b7b3e61db3f88632776b78b1db597af3f44c91ce17d533e14a25ce6a2816/zstandard-0.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:80080816b4f52a9d886e67f1f96912891074903238fe54f2de8b786f86baded2", size = 4857882 },
-    { url = "https://files.pythonhosted.org/packages/4a/7f/d8eb1cb123d8e4c541d4465167080bec88481ab54cd0b31eb4013ba04b95/zstandard-0.23.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84433dddea68571a6d6bd4fbf8ff398236031149116a7fff6f777ff95cad3df9", size = 4697672 },
-    { url = "https://files.pythonhosted.org/packages/5e/05/f7dccdf3d121309b60342da454d3e706453a31073e2c4dac8e1581861e44/zstandard-0.23.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ab19a2d91963ed9e42b4e8d77cd847ae8381576585bad79dbd0a8837a9f6620a", size = 5206043 },
-    { url = "https://files.pythonhosted.org/packages/86/9d/3677a02e172dccd8dd3a941307621c0cbd7691d77cb435ac3c75ab6a3105/zstandard-0.23.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:59556bf80a7094d0cfb9f5e50bb2db27fefb75d5138bb16fb052b61b0e0eeeb0", size = 5667390 },
-    { url = "https://files.pythonhosted.org/packages/41/7e/0012a02458e74a7ba122cd9cafe491facc602c9a17f590367da369929498/zstandard-0.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:27d3ef2252d2e62476389ca8f9b0cf2bbafb082a3b6bfe9d90cbcbb5529ecf7c", size = 5198901 },
-    { url = "https://files.pythonhosted.org/packages/65/3a/8f715b97bd7bcfc7342d8adcd99a026cb2fb550e44866a3b6c348e1b0f02/zstandard-0.23.0-cp310-cp310-win32.whl", hash = "sha256:5d41d5e025f1e0bccae4928981e71b2334c60f580bdc8345f824e7c0a4c2a813", size = 430596 },
-    { url = "https://files.pythonhosted.org/packages/19/b7/b2b9eca5e5a01111e4fe8a8ffb56bdcdf56b12448a24effe6cfe4a252034/zstandard-0.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:519fbf169dfac1222a76ba8861ef4ac7f0530c35dd79ba5727014613f91613d4", size = 495498 },
     { url = "https://files.pythonhosted.org/packages/9e/40/f67e7d2c25a0e2dc1744dd781110b0b60306657f8696cafb7ad7579469bd/zstandard-0.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:34895a41273ad33347b2fc70e1bff4240556de3c46c6ea430a7ed91f9042aa4e", size = 788699 },
     { url = "https://files.pythonhosted.org/packages/e8/46/66d5b55f4d737dd6ab75851b224abf0afe5774976fe511a54d2eb9063a41/zstandard-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:77ea385f7dd5b5676d7fd943292ffa18fbf5c72ba98f7d09fc1fb9e819b34c23", size = 633681 },
     { url = "https://files.pythonhosted.org/packages/63/b6/677e65c095d8e12b66b8f862b069bcf1f1d781b9c9c6f12eb55000d57583/zstandard-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:983b6efd649723474f29ed42e1467f90a35a74793437d0bc64a5bf482bedfa0a", size = 4944328 },


### PR DESCRIPTION
Significantly redid the dataclass interface so each dataset is now an enum. This enables some really pretty API usage, such as 

```python
from evalio.datasets import NewerCollege2020

for mm in NewerCollege2020.short_experiment:
    do_something_cool()
```

You no longer need to remember string names, as the enum should autocomplete for you. I also propagated these changes through the cli and added some simple tests.