### PR TITLE
Fix stamp serialization and deserialization for experiments

### DIFF
--- a/python/evalio/cli/writer.py
+++ b/python/evalio/cli/writer.py
@@ -54,7 +54,7 @@ class TrajectoryWriter:
     def write(self, stamp: Stamp, pose: SE3):
         self.writer.writerow(
             [
-                stamp.to_sec(),
+                f"{stamp.sec}.{stamp.nsec:09}",
                 pose.trans[0],
                 pose.trans[1],
                 pose.trans[2],

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -1,7 +1,7 @@
-from evalio.types import SO3
 from evalio.types import Stamp
 from evalio.types import SE3, Trajectory
 from evalio.cli.stats import align_stamps, align_poses
+from utils import rand_se3, isclose_se3
 import numpy as np
 
 ID = SE3.identity()
@@ -74,25 +74,15 @@ def test_overstep():
         )
 
 
-def _rand_se3():
-    return SE3(rot=SO3.exp(np.random.rand(3)), trans=np.random.rand(3))
-
-
-def _isclose_se3(a: SE3, b: SE3):
-    diff = a * b.inverse()
-    assert np.allclose(diff.trans, np.zeros(3)), "Translations are off"
-    assert np.allclose(diff.rot.log(), np.zeros(3)), "Rotations are off"
-
-
 def test_align_poses():
     np.random.seed(0)
     gt = Trajectory(
         metadata={},
         stamps=[s(i) for i in range(10)],
-        poses=[_rand_se3() for _ in range(10)],
+        poses=[rand_se3() for _ in range(10)],
     )
 
-    offset = _rand_se3()
+    offset = rand_se3()
 
     traj2 = Trajectory(
         metadata={},
@@ -103,4 +93,4 @@ def test_align_poses():
     align_poses(traj2, gt)
 
     for a, b in zip(traj2.poses, gt.poses):
-        _isclose_se3(a, b)
+        assert isclose_se3(a, b), f"{a} != {b}"

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -1,12 +1,16 @@
+from evalio.datasets.loaders import load_pose_csv
+from evalio.types import Stamp, SE3, Trajectory
 from evalio.types import ImuMeasurement, LidarMeasurement
 from evalio.cli.parser import DatasetBuilder
 from evalio.datasets.base import Dataset
 import pytest
 from pathlib import Path
 import pickle
+from enum import Enum, auto
+import numpy as np
+from utils import check_lidar_eq, isclose_se3, rand_se3
 
-from utils import check_lidar_eq
-
+# ------------------------- Loading imu & lidar ------------------------- #
 data_dir = Path("tests/data")
 dataset_classes = DatasetBuilder._all_datasets()
 datasets = [
@@ -38,3 +42,65 @@ def test_load_lidar(dataset: Dataset):
         lidar_cached: LidarMeasurement = pickle.load(f)
 
     check_lidar_eq(lidar_cached, lidar)
+
+
+# ------------------------- Loading ground truth ------------------------- #
+class StampStyle(Enum):
+    Seconds = auto()
+    Nanoseconds = auto()
+    Split = auto()
+
+    def attributes(self) -> list[str]:
+        return {
+            StampStyle.Seconds: ["sec"],
+            StampStyle.Nanoseconds: ["nsec"],
+            StampStyle.Split: ["sec", "nsec"],
+        }[self]
+
+    def serialize_stamp(self, stamp: Stamp) -> str:
+        match self:
+            case StampStyle.Seconds:
+                return f"{stamp.sec}.{stamp.nsec:09}"
+            case StampStyle.Nanoseconds:
+                return f"{stamp.to_nsec()}"
+            case StampStyle.Split:
+                return f"{stamp.sec}, {stamp.nsec}"
+
+
+def fake_groundtruth() -> Trajectory:
+    stamps = [
+        Stamp.from_nsec(i + np.random.randint(-500, 500))
+        for i in range(1_000, 10_000, 1_000)
+    ]
+    poses = [rand_se3() for _ in range(len(stamps))]
+    return Trajectory(metadata={}, stamps=stamps, poses=poses)
+
+
+def serialize_gt(gt: Trajectory, style: StampStyle) -> list[str]:
+    def serialize_se3(se3: SE3) -> str:
+        return f"{se3.trans[0]}, {se3.trans[1]}, {se3.trans[2]}, {se3.rot.qx}, {se3.rot.qy}, {se3.rot.qz}, {se3.rot.qw}"
+
+    return [
+        f"{style.serialize_stamp(stamp)}, {serialize_se3(se3)}"
+        for stamp, se3 in zip(gt.stamps, gt.poses)
+    ]
+
+
+@pytest.mark.parametrize("style", list(StampStyle))
+def test_load_groundtruth(style: StampStyle, tmp_path: Path):
+    gt = fake_groundtruth()
+    gt_str = serialize_gt(gt, style)
+
+    gt_file = tmp_path / "gt.csv"
+    with open(gt_file, "w") as f:
+        f.write("\n".join(gt_str))
+
+    gt_returned = load_pose_csv(
+        gt_file, fieldnames=style.attributes() + ["x", "y", "z", "qx", "qy", "qz", "qw"]
+    )
+
+    for i, (exp, got) in enumerate(zip(gt.poses, gt_returned.poses)):
+        assert isclose_se3(exp, got), f"Pose {i} does not match"
+
+    for i, (exp, got) in enumerate(zip(gt.stamps, gt_returned.stamps)):
+        assert exp == got, f"Stamp {i} does not match"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,9 +14,20 @@ from rosbags.typesys.stores.ros1_noetic import (
     geometry_msgs__msg__Quaternion as RosQuaternion,
 )
 
-from evalio.types import ImuMeasurement, LidarMeasurement, Point
+from evalio.types import ImuMeasurement, LidarMeasurement, Point, SE3, SO3
 
 import numpy as np
+
+
+def isclose_se3(a: SE3, b: SE3) -> bool:
+    diff = a * b.inverse()
+    return np.allclose(diff.trans, np.zeros(3)) and np.allclose(
+        diff.rot.log(), np.zeros(3)
+    )
+
+
+def rand_se3():
+    return SE3(rot=SO3.exp(np.random.rand(3)), trans=np.random.rand(3))
 
 
 def check_lidar_eq(exp: LidarMeasurement, got: LidarMeasurement):


### PR DESCRIPTION
@DanMcGann I confirmed this was causing issues with saving/loading stamps. I think the main issue was serializing the stamp as a float. This PR changes to manually serializing the stamp as a second, but handling the sec/nsec as integers.

I also cleaned up the trajectory loading to use the same code we use in the ground truth loading to reduce code reuse. Also added a bunch of tests as well.