### PR TITLE
Fix pipeline binding

### DIFF
--- a/cpp/bindings/main.cpp
+++ b/cpp/bindings/main.cpp
@@ -19,6 +19,6 @@ PYBIND11_MODULE(_cpp, m) {
   evalio::makeConversions(m_helpers);
 
   auto m_pipelines = m.def_submodule("pipelines", "Pipelines used in evalio.");
-  evalio::make_pipeline(m_pipelines, "Pipeline");
+  evalio::make_pipeline(m_pipelines, "Pipeline", false);
   evalio::makePipelines(m_pipelines);
 }

--- a/cpp/bindings/main.cpp
+++ b/cpp/bindings/main.cpp
@@ -19,6 +19,6 @@ PYBIND11_MODULE(_cpp, m) {
   evalio::makeConversions(m_helpers);
 
   auto m_pipelines = m.def_submodule("pipelines", "Pipelines used in evalio.");
-  evalio::makeBasePipeline(m_pipelines, "Pipeline");
+  evalio::makeBasePipeline(m_pipelines);
   evalio::makePipelines(m_pipelines);
 }

--- a/cpp/bindings/main.cpp
+++ b/cpp/bindings/main.cpp
@@ -19,6 +19,6 @@ PYBIND11_MODULE(_cpp, m) {
   evalio::makeConversions(m_helpers);
 
   auto m_pipelines = m.def_submodule("pipelines", "Pipelines used in evalio.");
-  evalio::make_pipeline(m_pipelines, "Pipeline", false);
+  evalio::makeBasePipeline(m_pipelines, "Pipeline");
   evalio::makePipelines(m_pipelines);
 }

--- a/cpp/bindings/main.cpp
+++ b/cpp/bindings/main.cpp
@@ -3,10 +3,10 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "bindings/pipeline.h"
 #include "bindings/pipelines/bindings.h"
 #include "bindings/ros_pc2.h"
 #include "bindings/types.h"
+#include "evalio/bindings.h"
 
 PYBIND11_MODULE(_cpp, m) {
   auto m_types = m.def_submodule(
@@ -19,6 +19,6 @@ PYBIND11_MODULE(_cpp, m) {
   evalio::makeConversions(m_helpers);
 
   auto m_pipelines = m.def_submodule("pipelines", "Pipelines used in evalio.");
-  evalio::makeBasePipeline(m_pipelines);
+  evalio::make_pipeline(m_pipelines, "Pipeline");
   evalio::makePipelines(m_pipelines);
 }

--- a/cpp/evalio/bindings.h
+++ b/cpp/evalio/bindings.h
@@ -51,8 +51,8 @@ public:
   }
 };
 
-inline void makeBasePipeline(py::module &m, const char *name = "_pipeline") {
-  py::class_<evalio::Pipeline, PyPipeline>(m, name)
+inline void makeBasePipeline(py::module &m) {
+  py::class_<evalio::Pipeline, PyPipeline>(m, "Pipeline")
       .def(py::init<>())
       .def_static("name", &evalio::Pipeline::name)
       .def_static("url", &evalio::Pipeline::url)

--- a/cpp/evalio/bindings.h
+++ b/cpp/evalio/bindings.h
@@ -51,9 +51,8 @@ public:
   }
 };
 
-inline void make_pipeline(py::module &m, const char *name = "_pipeline",
-                          bool local = true) {
-  py::class_<evalio::Pipeline, PyPipeline>(m, name, py::module_local(local))
+inline void makeBasePipeline(py::module &m, const char *name = "_pipeline") {
+  py::class_<evalio::Pipeline, PyPipeline>(m, name)
       .def(py::init<>())
       .def_static("name", &evalio::Pipeline::name)
       .def_static("url", &evalio::Pipeline::url)
@@ -67,6 +66,20 @@ inline void make_pipeline(py::module &m, const char *name = "_pipeline",
       .def("set_imu_params", &evalio::Pipeline::set_imu_params, "params"_a)
       .def("set_lidar_params", &evalio::Pipeline::set_lidar_params, "params"_a)
       .def("set_imu_T_lidar", &evalio::Pipeline::set_imu_T_lidar, "T"_a);
+}
+
+inline void setup(py::module &m) {
+  // NOTE: typeid are not guaranteed to be unique across building from different
+  // compilers
+  // https://github.com/pybind/pybind11/issues/877#issuecomment-304464896
+  // Ideally, if built using the same compiler as evalio (unlikely), this should
+  // work import the original wrapper for Pipeline
+  py::module evalio = py::module::import("evalio");
+  // Otherwise, build a new pipeline base class
+  // This should be fine, as pipelines are all exclusively used in python
+  if (py::detail::get_type_info(typeid(evalio::Pipeline)) == nullptr) {
+    evalio::makeBasePipeline(m);
+  };
 }
 
 } // namespace evalio

--- a/cpp/evalio/bindings.h
+++ b/cpp/evalio/bindings.h
@@ -51,8 +51,9 @@ public:
   }
 };
 
-inline void make_pipeline(py::module &m, const char *name = "_pipeline") {
-  py::class_<evalio::Pipeline, PyPipeline>(m, name)
+inline void make_pipeline(py::module &m, const char *name = "_pipeline",
+                          bool local = true) {
+  py::class_<evalio::Pipeline, PyPipeline>(m, name, py::module_local(local))
       .def(py::init<>())
       .def_static("name", &evalio::Pipeline::name)
       .def_static("url", &evalio::Pipeline::url)

--- a/cpp/evalio/bindings.h
+++ b/cpp/evalio/bindings.h
@@ -51,8 +51,8 @@ public:
   }
 };
 
-inline void makeBasePipeline(py::module &m) {
-  py::class_<evalio::Pipeline, PyPipeline>(m, "Pipeline")
+inline void make_pipeline(py::module &m, const char *name = "_pipeline") {
+  py::class_<evalio::Pipeline, PyPipeline>(m, name)
       .def(py::init<>())
       .def_static("name", &evalio::Pipeline::name)
       .def_static("url", &evalio::Pipeline::url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ sdist.include = ["cpp/bindings/pipelines-src/*"]
 EVALIO_BUILD_PYTHON = true
 CMAKE_BUILD_TYPE = "Release"
 VCPKG_INSTALLED_DIR = "./.vcpkg_installed"
-VCPKG_INSTALL_OPTIONS = "--debug"
-
+# VCPKG_INSTALL_OPTIONS = "--debug"
 
 [tool.cibuildwheel]
 build = ["cp*-manylinux_x86_64", "cp*-macosx_x86_64", "cp*-macosx_arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ CMAKE_BUILD_TYPE = "Release"
 VCPKG_INSTALLED_DIR = "./.vcpkg_installed"
 VCPKG_INSTALL_OPTIONS = "--debug"
 
+
 [tool.cibuildwheel]
 build = ["cp*-manylinux_x86_64", "cp*-macosx_x86_64", "cp*-macosx_arm64"]
 skip = ["cp310-*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ sdist.include = ["cpp/bindings/pipelines-src/*"]
 EVALIO_BUILD_PYTHON = true
 CMAKE_BUILD_TYPE = "Release"
 VCPKG_INSTALLED_DIR = "./.vcpkg_installed"
+VCPKG_INSTALL_OPTIONS = "--debug"
 
 [tool.cibuildwheel]
 build = ["cp*-manylinux_x86_64", "cp*-macosx_x86_64", "cp*-macosx_arm64"]


### PR DESCRIPTION
I had some issues with connecting pybind11 modules when building external pipelines. Turns out to do module importing, they all have to have the same(-ish) compiler and STL for [this to work](https://github.com/pybind/pybind11/issues/877#issuecomment-304464896) which is usually not going to be the case!

This PR makes a workaround for this by making `evalio::make_pipeline` external. This allows users implementing custom pipelines to be able to simply create a new base pipeline class. As a consequence, due to these being different base classes, we have to work a bit harder to check for subclassing pipelines.