### PR TITLE
Fix downloads

### DIFF
--- a/python/evalio/datasets/enwide.py
+++ b/python/evalio/datasets/enwide.py
@@ -151,20 +151,7 @@ class EnWide(Dataset):
         }[self.seq_name]
 
     def download(self):
-        bag_date = {
-            "field_d": "2023-08-09-19-25-45",
-            "field_s": "2023-08-09-19-05-05",
-            "intersection_d": "2023-08-09-17-58-11",
-            "intersection_s": "2023-08-09-16-19-09",
-            "katzensee_d": "2023-08-21-10-29-20",
-            "katzensee_s": "2023-08-21-10-20-22",
-            "runway_d": "2023-08-09-18-52-05",
-            "runway_s": "2023-08-09-18-44-24",
-            "tunnel_d": "2023-08-08-17-50-31",
-            "tunnel_s": "2023-08-08-17-12-37",
-        }[self.seq_name]
-        bag_file = f"{bag_date}-{self.seq_name}.bag"
-        gt_file = f"gt-{self.seq_name}.csv"
+        bag_file, gt_file = self.files()
 
         url = f"http://robotics.ethz.ch/~asl-datasets/2024_ICRA_ENWIDE/{self.seq_name}/"
 

--- a/python/evalio/datasets/helipr.py
+++ b/python/evalio/datasets/helipr.py
@@ -15,6 +15,7 @@ from .base import (
 from evalio.types import SE3, SO3, Stamp
 from evalio.datasets.loaders import RawDataIter, load_pose_csv
 
+import os
 
 """
 Note, we do everything based off of the Ouster Lidar, mounted at the top of the vehicle.
@@ -165,7 +166,7 @@ class HeLiPR(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
-        folder_trail = f"{self.folder}/"
+        folder_trail = f"{self.folder}{os.sep}"
         gdown.download(id=id_gt, output=folder_trail, resume=True)
         gdown.download(id=id_imu, output=folder_trail, resume=True)
 

--- a/python/evalio/datasets/multi_campus.py
+++ b/python/evalio/datasets/multi_campus.py
@@ -12,6 +12,8 @@ from evalio.datasets.loaders import (
 from evalio.types import Trajectory
 import numpy as np
 
+import os
+
 from .base import (
     SE3,
     Dataset,
@@ -183,7 +185,18 @@ class MultiCampus(Dataset):
 
     # ------------------------- For downloading ------------------------- #
     def files(self) -> list[str]:
-        return ["ouster.bag", "pose_inW.csv", "vectornav.bag"]
+        if "ntu" in self.seq_name:
+            beams = 128
+            imu = "vn100"
+        else:
+            beams = 64
+            imu = "vn200"
+
+        return [
+            f"{self.seq_name}_{imu}.bag",
+            f"{self.seq_name}_os1_{beams}.bag",
+            "pose_inW.csv",
+        ]
 
     def download(self):
         ouster_url = {
@@ -253,11 +266,7 @@ class MultiCampus(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
-        # TODO: Make these download without changing the filename
-        gdown.download(id=gt_url, output=str(self.folder / "pose_inW.csv"), resume=True)
-        gdown.download(
-            id=ouster_url, output=str(self.folder / "ouster.bag"), resume=True
-        )
-        gdown.download(
-            id=imu_url, output=str(self.folder / "vectornav.bag"), resume=True
-        )
+        folder = f"{self.folder}{os.sep}"
+        gdown.download(id=gt_url, output=folder, resume=True)
+        gdown.download(id=ouster_url, output=folder, resume=True)
+        gdown.download(id=imu_url, output=folder, resume=True)

--- a/python/evalio/datasets/newer_college_2020.py
+++ b/python/evalio/datasets/newer_college_2020.py
@@ -10,6 +10,7 @@ from evalio.datasets.loaders import (
 from evalio.types import Trajectory, SO3
 import numpy as np
 from enum import auto
+import os
 
 from .base import (
     SE3,
@@ -44,16 +45,16 @@ class NewerCollege2020(Dataset):
         )
 
     def ground_truth_raw(self) -> Trajectory:
-        # For some reason bag #7 is different
+        # For some reason bag parkland mound is different
         if self.seq_name == "parkland_mound":
             return load_pose_csv(
-                self.folder / "ground_truth.csv",
+                self.folder / "registered_poses.csv",
                 ["sec", "x", "y", "z", "qx", "qy", "qz", "qw"],
                 delimiter=" ",
             )
 
         return load_pose_csv(
-            self.folder / "ground_truth.csv",
+            self.folder / "registered_poses.csv",
             ["sec", "nsec", "x", "y", "z", "qx", "qy", "qz", "qw"],
         )
 
@@ -141,7 +142,7 @@ class NewerCollege2020(Dataset):
                 "rooster_2020-07-10-09-34-11_1.bag",
                 "rooster_2020-07-10-09-36-58_2.bag",
             ],
-        }[self.seq_name] + ["ground_truth.csv"]
+        }[self.seq_name] + ["registered_poses.csv"]
 
     def download(self):
         folder_id = {
@@ -163,7 +164,7 @@ class NewerCollege2020(Dataset):
         import gdown  # type: ignore
 
         print(f"Downloading to {self.folder}...")
+
         self.folder.mkdir(parents=True, exist_ok=True)
-        # TODO: Make this download to an identical name as it is online
-        gdown.download(id=gt_url, output=self.folder, resume=True)
+        gdown.download(id=gt_url, output=f"{self.folder}{os.sep}", resume=True)
         gdown.download_folder(id=folder_id, output=str(self.folder), resume=True)

--- a/python/evalio/datasets/oxford_spires.py
+++ b/python/evalio/datasets/oxford_spires.py
@@ -19,6 +19,8 @@ from .base import (
     DatasetIterator,
 )
 
+import os
+
 """
 Note, we skip over a number of trajectories due to missing ground truth data.
 https://docs.google.com/document/d/1RS9QSOP4rC7BWoCD6EYUCm9uV_oMkfa3b61krn9OLG8/edit?tab=t.0
@@ -60,7 +62,7 @@ class OxfordSpires(Dataset):
         # Some of these are within a few milliseconds of each other
         # skip over ones that are too close
         traj = load_pose_csv(
-            self.folder / "gt-tum.csv",
+            self.folder / "gt-tum.txt",
             ["sec", "x", "y", "z", "qx", "qy", "qz", "qw"],
             delimiter=" ",
         )
@@ -143,66 +145,66 @@ class OxfordSpires(Dataset):
             "christ_church_02": [
                 "1710754066_2024-03-18-09-27-47_0",
                 "1710754066_2024-03-18-09-36-49_1",
-                "gt-tum.csv",
+                "gt-tum.txt",
             ],
             "blenheim_palace_01": [
                 "1710406700_2024-03-14-08-58-21_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "christ_church_05": [
                 "1710926317_2024-03-20-09-18-38_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "keble_college_03": [
                 "1710256011_2024-03-12-15-06-52_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "christ_church_01": [
                 "1710752531_2024-03-18-09-02-12_0",
                 "1710752531_2024-03-18-09-11-55_1",
-                "gt-tum.csv",
+                "gt-tum.txt",
             ],
             "bodleian_library_02": [
                 "1716183690_2024-05-20-06-41-31_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "blenheim_palace_02": [
                 "1710407340_2024-03-14-09-09-01_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "keble_college_04": [
                 "1710256650_2024-03-12-15-17-31_0",
                 "1710256650_2024-03-12-15-26-05_1",
-                "gt-tum.csv",
+                "gt-tum.txt",
             ],
             "observatory_quarter_01": [
                 "1710338090_2024-03-13-13-54-51_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "christ_church_03": [
                 "1710755015_2024-03-18-09-43-36_0_blurred_filtered.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "blenheim_palace_05": [
                 "1710410169_2024-03-14-09-56-09_0_blurred_filtered.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "observatory_quarter_02": [
                 "1710338490_2024-03-13-14-01-30_blurred_filtered.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
             "keble_college_02": [
                 "1710255615_2024-03-12-15-00-16_0_blurred_filtered_compressed.db3",
-                "gt-tum.csv",
+                "gt-tum.txt",
                 "metadata.yaml",
             ],
         }[self.seq_name]
@@ -247,5 +249,5 @@ class OxfordSpires(Dataset):
 
         print(f"Downloading to {self.folder}...")
         self.folder.mkdir(parents=True, exist_ok=True)
-        gdown.download(id=gt_url, output=str(self.folder / "gt-tum.csv"), resume=True)
+        gdown.download(id=gt_url, output=f"{self.folder}{os.sep}", resume=True)
         gdown.download_folder(id=folder_id, output=str(self.folder), resume=True)


### PR DESCRIPTION
This PR fixes #21 and ensures that all files download to the same filename as listed online. This will allow users to easily download files by hand if needed.

[Here's a simple conversion script that renames files from the previous filenames if needed](https://gist.github.com/contagon/4ad71e20f9fd8b27105ae5a4eaa77618)