### PR TITLE
Bump cmake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif()
 
 # ------------------------- Basics ------------------------- #
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 project(EVALIO VERSION 0.2.0 LANGUAGES CXX)
 
 # Enforce C++17 for std::variant amongst others


### PR DESCRIPTION
Super simple bump to the `cmake_minimum_required` version. 

Specifically setting to `3.24` as I believe that is the version that contains the newest feature used by evalio.

That feature being the `FIND_PACKAGE_ARGS` argument of `FetchContent_Declare` which was introduced in 3.24
Ref: https://cmake.org/cmake/help/latest/module/FetchContent.html